### PR TITLE
Use Python file IO to read char_list file for portability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/ndl-lab/text_recognition.git
 [submodule "src/ndl_layout"]
 	path = src/ndl_layout
-	url = https://github.com/ndl-lab/ndl_layout.git
+	url = https://github.com/syoyo/ndl_layout.git

--- a/cli/procs/line_ocr.py
+++ b/cli/procs/line_ocr.py
@@ -27,9 +27,11 @@ class LineOcrProcess(BaseInferenceProcess):
             実行される順序を表す数値。
         """
         super().__init__(cfg, pid, '_line_ocr')
-        process1 = subprocess.Popen(['cat', self.cfg['line_ocr']['char_list']], stdout=subprocess.PIPE)
-        process2 = subprocess.Popen(['tr', '-d', '\\n'], stdin=process1.stdout, stdout=subprocess.PIPE)
-        self.character = '〓' + process2.stdout.read().decode()
+
+        char_list_filename = self.cfg['line_ocr']['char_list']
+        with open(char_list_filename, encoding='utf-8') as f:
+            lines = f.read().splitlines()
+            self.character = '〓' + ''.join(lines)
 
         from src.text_recognition.text_recognition import InferencerWithCLI
         self._inferencer = InferencerWithCLI(self.cfg['line_ocr'], self.character)

--- a/download.txt
+++ b/download.txt
@@ -1,0 +1,5 @@
+wget -q https://lab.ndl.go.jp/dataset/ndlocr/text_recognition/mojilist_NDL.txt -P ./src/text_recognition/models
+wget -q https://lab.ndl.go.jp/dataset/ndlocr/text_recognition/ndlenfixed64-mj0-synth1.pth -P ./src/text_recognition/models
+wget -q https://lab.ndl.go.jp/dataset/ndlocr/ndl_layout/ndl_layout_config.py -P ./src/ndl_layout/models
+wget -q https://lab.ndl.go.jp/dataset/ndlocr/ndl_layout/epoch_140_all_eql_bt.pth -P ./src/ndl_layout/models
+wget -q https://lab.ndl.go.jp/dataset/ndlocr/separate_pages_ssd/weights.hdf5 -P ./src/separate_pages_ssd/ssd_tools


### PR DESCRIPTION
`cat` and `tr` is not available on Windows, thus replaced it with equivalent Python code for portability(Assume char_list file is encoded in UTF-8)