### PR TITLE
パッケージインストール時のエラー

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
     && apt -y install wget python3-distutils \
     && wget https://bootstrap.pypa.io/get-pip.py \
     && python get-pip.py \
-    && python -m pip install --upgrade pip==23.2.1
+    && python -m pip install --upgrade pip==24.0
 
 ENV TZ=Asia/Tokyo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,8 @@ RUN set -x \
     && ln -s /usr/bin/python3.8 /usr/bin/python \
     && apt -y install wget python3-distutils \
     && wget https://bootstrap.pypa.io/get-pip.py \
-    && python get-pip.py
+    && python get-pip.py \
+    && python -m pip install --upgrade pip==23.2.1
 
 ENV TZ=Asia/Tokyo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
最新バージョンのpipだと、パッケージインストール時にエラーとなり、dockerコンテナのビルドが出来ませんでした。pipのバージョンを<24.1とするよう求められたので、24.0に変更しました。あまり詳しくないのでこれが最適解なのか分かりませんが、ご検討ください。